### PR TITLE
fix(account): Show type on creation

### DIFF
--- a/src/app/modules/account/pages/account/account.component.ts
+++ b/src/app/modules/account/pages/account/account.component.ts
@@ -87,6 +87,7 @@ export class AccountComponent {
     dialogRef.afterClosed().subscribe(result => {
       if (result) {
         this.accountService.createAccount(result).subscribe((newAccount => {
+          newAccount.type.fullName = result.type.fullName;
           this.accounts.push(newAccount);
           this.updateAccountArray();
         }));


### PR DESCRIPTION
The account type is now displayed in the table when an account is created.

fixes: https://app.asana.com/0/580094986677777/1200866735800536/f